### PR TITLE
Fix: return statement for multiply documents remove

### DIFF
--- a/packages/Document/AliveCollection.php
+++ b/packages/Document/AliveCollection.php
@@ -91,7 +91,7 @@ class AliveCollection implements ArrayAccess, Countable, DocumentCollection
     public function remove(array|string $_id): bool
     {
         if (is_array($_id)) {
-            $this->deleteDocuments($this->name, $_id, $this->refresh);
+            return $this->deleteDocuments($this->name, $_id, $this->refresh);
         }
 
         return $this->deleteDocument($this->name, $_id, $this->refresh);


### PR DESCRIPTION
Without `return` statement execution of function continue and fail with `TypeError`: $_id must be string.